### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -3,6 +3,9 @@ name: Build and Release ODR Artifacts
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   ##################################
@@ -264,6 +267,9 @@ jobs:
     name: Create GitHub Release for ODR-PadEnc
     runs-on: ubuntu-24.04
     needs: build_padenc
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -319,6 +325,9 @@ jobs:
     name: Create GitHub Release for ODR-AudioEnc
     runs-on: ubuntu-24.04
     needs: build_audioenc
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-odrbuilds/security/code-scanning/12](https://github.com/oszuidwest/zwfm-odrbuilds/security/code-scanning/12)

To fix the issue, we will add a `permissions` block to the `release_audioenc` job and other relevant jobs in the workflow. The permissions will be scoped to the minimum required for the tasks performed in each job. Specifically:
1. For the `release_audioenc` job:
   - `contents: write` is needed to create and push tags.
   - `packages: write` is needed to create releases and upload assets.
2. For the `release_padenc` job, similar permissions will be applied since it performs analogous tasks.
3. For the build jobs (`build_padenc` and `build_audioenc`), only `contents: read` is required to access the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
