### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -3,6 +3,10 @@ name: Build and Release ODR Artifacts
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
 
   ##################################


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-odrbuilds/security/code-scanning/4](https://github.com/oszuidwest/zwfm-odrbuilds/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
