### PR TITLE
Add Ubuntu 26.04 LTS build support

### DIFF
--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -443,6 +443,15 @@ jobs:
       - name: Build ODR-DabMux
         working-directory: ODR-DabMux
         run: |
+          # Workaround: Boost >= 1.69 made boost_system header-only.
+          # Some distros (e.g. Ubuntu 26.04 with Boost 1.90) no longer ship libboost_system.so.
+          # See: https://github.com/Opendigitalradio/ODR-DabMux/issues/90
+          if ! find /usr -name "libboost_system*.so*" -o -name "libboost_system*.a" 2>/dev/null | grep -q .; then
+            echo "No Boost::System library found, applying header-only workaround"
+            sed -i 's/^AX_BOOST_SYSTEM$/# AX_BOOST_SYSTEM - skipped, header-only/' configure.ac
+            sed -i 's/$(BOOST_SYSTEM_LIB)//' Makefile.am
+          fi
+
           ./bootstrap.sh
           ./configure
           make -j"$(nproc)"

--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -65,6 +65,14 @@ jobs:
             image: "ubuntu:24.04"
             arch: "arm64"
             runner: "ubuntu-24.04-arm"
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
           - os: alpine322
             image: "alpine:3.22"
             arch: "amd64"
@@ -216,6 +224,26 @@ jobs:
             arch: "arm64"
             runner: "ubuntu-24.04-arm"
             build: minimal
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+            build: full
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+            build: minimal
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
+            build: full
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
+            build: minimal
           - os: alpine322
             image: "alpine:3.22"
             arch: "amd64"
@@ -346,6 +374,14 @@ jobs:
             runner: "ubuntu-24.04"
           - os: ubuntu2404
             image: "ubuntu:24.04"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
             arch: "arm64"
             runner: "ubuntu-24.04-arm"
           - os: alpine322
@@ -498,6 +534,26 @@ jobs:
             build: cli
           - os: ubuntu2404
             image: "ubuntu:24.04"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
+            build: gtk
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+            build: cli
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "amd64"
+            runner: "ubuntu-24.04"
+            build: gtk
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
+            build: cli
+          - os: ubuntu2604
+            image: "ubuntu:26.04"
             arch: "arm64"
             runner: "ubuntu-24.04-arm"
             build: gtk

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The binaries are built for multiple operating systems and architectures:
 - Ubuntu 24.04 LTS - filename: `ubuntu2404`
   - AMD64
   - ARM64
+- Ubuntu 26.04 LTS - filename: `ubuntu2604`
+  - AMD64
+  - ARM64
 - Alpine 3.22 - filename: `alpine322`
   - AMD64
 
@@ -36,6 +39,9 @@ The binaries are built for multiple operating systems and architectures:
   - AMD64: Minimal and Full builds
   - ARM64: Minimal and Full builds
 - Ubuntu 24.04 LTS - filename: `ubuntu2404`
+  - AMD64: Minimal and Full builds
+  - ARM64: Minimal and Full builds
+- Ubuntu 26.04 LTS - filename: `ubuntu2604`
   - AMD64: Minimal and Full builds
   - ARM64: Minimal and Full builds
 - Alpine 3.22 - filename: `alpine322`
@@ -51,6 +57,9 @@ The binaries are built for multiple operating systems and architectures:
 - Ubuntu 24.04 LTS - filename: `ubuntu2404`
   - AMD64
   - ARM64
+- Ubuntu 26.04 LTS - filename: `ubuntu2604`
+  - AMD64
+  - ARM64
 - Alpine 3.22 - filename: `alpine322`
   - AMD64
 
@@ -62,6 +71,9 @@ The binaries are built for multiple operating systems and architectures:
   - AMD64: CLI and GTK builds
   - ARM64: CLI and GTK builds
 - Ubuntu 24.04 LTS - filename: `ubuntu2404`
+  - AMD64: CLI and GTK builds
+  - ARM64: CLI and GTK builds
+- Ubuntu 26.04 LTS - filename: `ubuntu2604`
   - AMD64: CLI and GTK builds
   - ARM64: CLI and GTK builds
 - macOS - filename: `macos`


### PR DESCRIPTION
## Summary
- Add Ubuntu 26.04 LTS (Resolute Raccoon) build matrix entries for all tools: ODR-PadEnc, ODR-AudioEnc (minimal + full), ODR-DabMux, and DABlin (cli + gtk) on both amd64 and arm64
- Add workaround for ODR-DabMux build failure caused by Boost 1.90 making `boost_system` fully header-only (no `.so`/`.a` files shipped)
- Update README.md with Ubuntu 26.04 documentation

## Boost workaround
Ubuntu 26.04 ships Boost 1.90 which no longer includes `libboost_system.so`. The `AX_BOOST_SYSTEM` autoconf macro in ODR-DabMux fails because it can't find the library. The workaround detects this and patches `configure.ac`/`Makefile.am` at build time.

Upstream issue: https://github.com/Opendigitalradio/ODR-DabMux/issues/90

## Test plan
- [x] ODR-PadEnc builds successfully on `ubuntu:26.04`
- [x] ODR-AudioEnc (full) builds successfully on `ubuntu:26.04`
- [x] ODR-AudioEnc (minimal) builds successfully on `ubuntu:26.04`
- [x] ODR-DabMux builds successfully on `ubuntu:26.04` with Boost workaround
- [x] DABlin (cli) builds successfully on `ubuntu:26.04`
- [x] DABlin (gtk) builds successfully on `ubuntu:26.04`
- [x] Workaround does not affect Debian 13 (Boost 1.83 still ships `.so`)
- [x] Run full workflow on GitHub Actions