### PR TITLE
Upgrade Alpine 3.22 to 3.23, add ARM64 Alpine builds

### DIFF
--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -73,10 +73,14 @@ jobs:
             image: "ubuntu:26.04"
             arch: "arm64"
             runner: "ubuntu-24.04-arm"
-          - os: alpine322
-            image: "alpine:3.22"
+          - os: alpine323
+            image: "alpine:3.23"
             arch: "amd64"
             runner: "ubuntu-24.04"
+          - os: alpine323
+            image: "alpine:3.23"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
     steps:
       - name: Checkout repository (for build.env file)
         uses: actions/checkout@v6
@@ -102,7 +106,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.os }}" = "alpine322" ]; then
+          if [ -f /etc/alpine-release ]; then
             apk add --no-cache \
               build-base automake autoconf libtool \
               imagemagick-dev \
@@ -244,15 +248,25 @@ jobs:
             arch: "arm64"
             runner: "ubuntu-24.04-arm"
             build: minimal
-          - os: alpine322
-            image: "alpine:3.22"
+          - os: alpine323
+            image: "alpine:3.23"
             arch: "amd64"
             runner: "ubuntu-24.04"
             build: minimal
-          - os: alpine322
-            image: "alpine:3.22"
+          - os: alpine323
+            image: "alpine:3.23"
             arch: "amd64"
             runner: "ubuntu-24.04"
+            build: full
+          - os: alpine323
+            image: "alpine:3.23"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
+            build: minimal
+          - os: alpine323
+            image: "alpine:3.23"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
             build: full
     steps:
       - name: Checkout repository (for build.env file)
@@ -279,9 +293,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.os }}" = "alpine322" ]; then
+          if [ -f /etc/alpine-release ]; then
             # Enable community repository
-            echo "https://dl-cdn.alpinelinux.org/alpine/v3.22/community" >> /etc/apk/repositories
+            ALPINE_VERSION=$(cat /etc/alpine-release | cut -d. -f1-2)
+            echo "https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/community" >> /etc/apk/repositories
             apk update
             apk add --no-cache \
               build-base automake autoconf libtool \
@@ -384,10 +399,14 @@ jobs:
             image: "ubuntu:26.04"
             arch: "arm64"
             runner: "ubuntu-24.04-arm"
-          - os: alpine322
-            image: "alpine:3.22"
+          - os: alpine323
+            image: "alpine:3.23"
             arch: "amd64"
             runner: "ubuntu-24.04"
+          - os: alpine323
+            image: "alpine:3.23"
+            arch: "arm64"
+            runner: "ubuntu-24.04-arm"
     steps:
       - name: Checkout repository (for build.env file)
         uses: actions/checkout@v6
@@ -413,7 +432,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.os }}" = "alpine322" ]; then
+          if [ -f /etc/alpine-release ]; then
             apk add --no-cache \
               build-base automake autoconf libtool \
               zeromq-dev \

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ The binaries are built for multiple operating systems and architectures:
 - Ubuntu 26.04 LTS - filename: `ubuntu2604`
   - AMD64
   - ARM64
-- Alpine 3.22 - filename: `alpine322`
+- Alpine 3.23 - filename: `alpine323`
   - AMD64
+  - ARM64
 
 ### ODR-AudioEnc
 - Debian 12 (Bookworm) - filename: `debian12`
@@ -44,8 +45,9 @@ The binaries are built for multiple operating systems and architectures:
 - Ubuntu 26.04 LTS - filename: `ubuntu2604`
   - AMD64: Minimal and Full builds
   - ARM64: Minimal and Full builds
-- Alpine 3.22 - filename: `alpine322`
+- Alpine 3.23 - filename: `alpine323`
   - AMD64: Minimal and Full builds
+  - ARM64: Minimal and Full builds
 
 ### ODR-DabMux
 - Debian 12 (Bookworm) - filename: `debian12`
@@ -60,8 +62,9 @@ The binaries are built for multiple operating systems and architectures:
 - Ubuntu 26.04 LTS - filename: `ubuntu2604`
   - AMD64
   - ARM64
-- Alpine 3.22 - filename: `alpine322`
+- Alpine 3.23 - filename: `alpine323`
   - AMD64
+  - ARM64
 
 ### DABlin
 - Debian 12 (Bookworm) - filename: `debian12`
@@ -80,7 +83,6 @@ The binaries are built for multiple operating systems and architectures:
   - AMD64 (Intel): CLI and GTK builds
   - ARM64 (Apple Silicon): CLI and GTK builds
 
-**Note:** ARM64 builds are not available for Alpine due to current limitations in GitHub Actions runners.
 
 ## Using the Prebuilt ODR Tools
 
@@ -91,7 +93,7 @@ Visit the [Releases](https://github.com/oszuidwest/zwfm-odrbuilds/releases) page
 - `odr-padenc-v3.1.0-debian12-amd64` (Debian 12)
 - `odr-padenc-v3.1.0-debian13-amd64` (Debian 13)
 - `odr-padenc-v3.1.0-ubuntu2404-amd64` (Ubuntu 24.04)
-- `odr-padenc-v3.1.0-alpine322-amd64` (Alpine 3.22)
+- `odr-padenc-v3.1.0-alpine323-amd64` (Alpine 3.23)
 - `odr-audioenc-next-minimal-debian12-amd64` (AudioEnc with variant)
 - `odr-audioenc-next-full-ubuntu2404-arm64` (AudioEnc full variant)
 - `odr-dabmux-v5.4.1-ubuntu2404-amd64` (DabMux)
@@ -113,8 +115,8 @@ chmod +x odr-padenc
 # Or download Ubuntu 24.04 version
 wget https://github.com/oszuidwest/zwfm-odrbuilds/releases/download/odr-padenc-v3.1.0/odr-padenc-v3.1.0-ubuntu2404-amd64 -O odr-padenc
 
-# Or download Alpine 3.22 version
-wget https://github.com/oszuidwest/zwfm-odrbuilds/releases/download/odr-padenc-v3.1.0/odr-padenc-v3.1.0-alpine322-amd64 -O odr-padenc
+# Or download Alpine 3.23 version
+wget https://github.com/oszuidwest/zwfm-odrbuilds/releases/download/odr-padenc-v3.1.0/odr-padenc-v3.1.0-alpine323-amd64 -O odr-padenc
 
 # Download DABlin CLI for Linux
 wget https://github.com/oszuidwest/zwfm-odrbuilds/releases/download/dablin-v1.16.1/dablin-v1.16.1-cli-ubuntu2404-amd64 -O dablin


### PR DESCRIPTION
## Summary
- Replace Alpine 3.22 with 3.23 for all tools (PadEnc, AudioEnc, DabMux)
- Add ARM64 builds for Alpine, now that GitHub Actions ARM runners support container jobs
- Make Alpine detection generic (`/etc/alpine-release` instead of hardcoded OS check)
- Derive community repo URL dynamically from Alpine version
- Remove outdated "ARM64 not available for Alpine" note from README

## Test plan
- [x] ODR-PadEnc builds on Alpine 3.23 (amd64, local Docker)
- [x] ODR-AudioEnc full builds on Alpine 3.23 (amd64, local Docker)
- [x] ODR-AudioEnc minimal builds on Alpine 3.23 (amd64, local Docker)
- [x] ODR-DabMux builds on Alpine 3.23 (amd64, local Docker)
- [ ] Run full workflow on GitHub Actions (amd64 + arm64)