### PR TITLE
Fix Alpine ARM64 failures, add fail-fast: false

### DIFF
--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -39,7 +39,6 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -163,7 +162,6 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -353,7 +351,6 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -488,7 +485,6 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -671,7 +667,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     if: ${{ inputs.build_dablin }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: macos

--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -39,6 +39,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -77,10 +78,6 @@ jobs:
             image: "alpine:3.23"
             arch: "amd64"
             runner: "ubuntu-24.04"
-          - os: alpine323
-            image: "alpine:3.23"
-            arch: "arm64"
-            runner: "ubuntu-24.04-arm"
     steps:
       - name: Checkout repository (for build.env file)
         uses: actions/checkout@v6
@@ -166,6 +163,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -257,16 +255,6 @@ jobs:
             image: "alpine:3.23"
             arch: "amd64"
             runner: "ubuntu-24.04"
-            build: full
-          - os: alpine323
-            image: "alpine:3.23"
-            arch: "arm64"
-            runner: "ubuntu-24.04-arm"
-            build: minimal
-          - os: alpine323
-            image: "alpine:3.23"
-            arch: "arm64"
-            runner: "ubuntu-24.04-arm"
             build: full
     steps:
       - name: Checkout repository (for build.env file)
@@ -365,6 +353,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -403,10 +392,6 @@ jobs:
             image: "alpine:3.23"
             arch: "amd64"
             runner: "ubuntu-24.04"
-          - os: alpine323
-            image: "alpine:3.23"
-            arch: "arm64"
-            runner: "ubuntu-24.04-arm"
     steps:
       - name: Checkout repository (for build.env file)
         uses: actions/checkout@v6
@@ -503,6 +488,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: debian12
@@ -685,6 +671,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     if: ${{ inputs.build_dablin }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ The binaries are built for multiple operating systems and architectures:
   - ARM64
 - Alpine 3.23 - filename: `alpine323`
   - AMD64
-  - ARM64
 
 ### ODR-AudioEnc
 - Debian 12 (Bookworm) - filename: `debian12`
@@ -47,7 +46,6 @@ The binaries are built for multiple operating systems and architectures:
   - ARM64: Minimal and Full builds
 - Alpine 3.23 - filename: `alpine323`
   - AMD64: Minimal and Full builds
-  - ARM64: Minimal and Full builds
 
 ### ODR-DabMux
 - Debian 12 (Bookworm) - filename: `debian12`
@@ -64,7 +62,6 @@ The binaries are built for multiple operating systems and architectures:
   - ARM64
 - Alpine 3.23 - filename: `alpine323`
   - AMD64
-  - ARM64
 
 ### DABlin
 - Debian 12 (Bookworm) - filename: `debian12`
@@ -83,6 +80,7 @@ The binaries are built for multiple operating systems and architectures:
   - AMD64 (Intel): CLI and GTK builds
   - ARM64 (Apple Silicon): CLI and GTK builds
 
+**Note:** ARM64 builds are not available for Alpine due to current limitations in GitHub Actions runners.
 
 ## Using the Prebuilt ODR Tools
 


### PR DESCRIPTION
## Summary
- Remove Alpine ARM64 matrix entries (GitHub Actions doesn't support JavaScript Actions in Alpine containers on ARM64 runners)
- Add `fail-fast: false` to all 5 build matrices so one failing job no longer cancels all other jobs
- Restore "ARM64 not available for Alpine" note in README

## Context
The previous PR added Alpine ARM64 builds, but these fail immediately with:
> JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected Linux Arm64

Without `fail-fast: false`, this single failure cascaded and cancelled all jobs in each matrix.

## Test plan
- [x] Run full workflow on GitHub Actions