### PR TITLE
Clean up workflows and Dockerfile

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -120,6 +120,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            build.env
+            docker
+          sparse-checkout-cone-mode: false
 
       - name: Load environment variables
         run: |

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Load environment variables
         id: env
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
@@ -123,20 +122,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Load environment variables
-        id: env
         run: |
-          # Source build.env file and export to GitHub environment
           set -a
           . ./build.env
           set +a
 
-          # Export to GitHub environment for use in subsequent steps
           {
             echo "REGISTRY=${{ needs.prepare.outputs.registry }}"
             echo "ORGANIZATION=${{ needs.prepare.outputs.organization }}"
-            echo "ODR_PADENC_VERSION=$ODR_PADENC_VERSION"
-            echo "ODR_AUDIOENC_VERSION=$ODR_AUDIOENC_VERSION"
-            echo "ODR_DABMUX_VERSION=$ODR_DABMUX_VERSION"
           } >> "$GITHUB_ENV"
 
           # Set version based on tool

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -22,10 +22,6 @@ permissions:
   contents: read
   security-events: write
 
-env:
-  REGISTRY: ghcr.io
-  DOCKERFILE_PATH: "docker/Dockerfile"
-
 jobs:
   security-scan:
     name: Security Scan
@@ -51,7 +47,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ${{ env.DOCKERFILE_PATH }}
+          file: docker/Dockerfile
           push: false
           pull: true
           load: true

--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -87,12 +87,10 @@ jobs:
 
       - name: Load configuration
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
 
-          # Export to environment
           {
             echo "VERSION=$ODR_PADENC_VERSION"
             echo "BRANCH=$ODR_PADENC_BRANCH"
@@ -264,12 +262,10 @@ jobs:
 
       - name: Load configuration
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
 
-          # Export to environment
           {
             echo "VERSION=$ODR_AUDIOENC_VERSION"
             echo "BRANCH=$ODR_AUDIOENC_BRANCH"
@@ -280,23 +276,27 @@ jobs:
       - name: Install dependencies
         run: |
           if [ -f /etc/alpine-release ]; then
-            # Enable community repository
             ALPINE_VERSION=$(cat /etc/alpine-release | cut -d. -f1-2)
             echo "https://dl-cdn.alpinelinux.org/alpine/v${ALPINE_VERSION}/community" >> /etc/apk/repositories
             apk update
             apk add --no-cache \
               build-base automake autoconf libtool \
-              zeromq-dev \
-              alsa-lib-dev jack-dev vlc-dev \
-              gstreamer-dev gst-plugins-base-dev \
-              curl-dev curl git
+              zeromq-dev curl-dev curl git
+            if [ "${{ matrix.build }}" = "full" ]; then
+              apk add --no-cache \
+                alsa-lib-dev jack-dev vlc-dev \
+                gstreamer-dev gst-plugins-base-dev
+            fi
           else
             apt-get update && apt-get install -y --no-install-recommends \
               build-essential automake libtool \
               libzmq3-dev libzmq5 \
-              libasound2-dev libjack-jackd2-dev libvlc-dev \
-              libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-              libcurl4-openssl-dev ca-certificates curl git && \
+              libcurl4-openssl-dev ca-certificates curl git
+            if [ "${{ matrix.build }}" = "full" ]; then
+              apt-get install -y --no-install-recommends \
+                libasound2-dev libjack-jackd2-dev libvlc-dev \
+                libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+            fi
             apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
           fi
 
@@ -399,12 +399,10 @@ jobs:
 
       - name: Load configuration
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
 
-          # Export to environment
           {
             echo "VERSION=$ODR_DABMUX_VERSION"
             echo "BRANCH=$ODR_DABMUX_BRANCH"
@@ -577,12 +575,10 @@ jobs:
 
       - name: Load configuration
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
 
-          # Export to environment
           {
             echo "VERSION=$DABLIN_VERSION"
             echo "BRANCH=$DABLIN_BRANCH"
@@ -695,12 +691,10 @@ jobs:
 
       - name: Load configuration
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
 
-          # Export to environment
           {
             echo "VERSION=$DABLIN_VERSION"
             echo "BRANCH=$DABLIN_BRANCH"
@@ -785,37 +779,33 @@ jobs:
     if: ${{ inputs.build_padenc && !cancelled() && !failure() }}
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            build.env
+          sparse-checkout-cone-mode: false
 
       - name: Load version
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
-
           echo "VERSION=$ODR_PADENC_VERSION" >> "$GITHUB_ENV"
 
-      - name: Download all artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          path: all_artifacts
-
-      - name: Organize PadEnc artifacts
-        run: |
-          mkdir -p padenc
-          mv all_artifacts/odr-padenc-* padenc/ || true
-          ls -l padenc
+          path: artifacts
+          pattern: odr-padenc-*
 
       - name: Create PadEnc Release and Upload Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: softprops/action-gh-release@v2
         with:
-          files: padenc/**
+          files: artifacts/**
           tag_name: odr-padenc-${{ env.VERSION }}
           name: "ODR-PadEnc ${{ env.VERSION }}"
           generate_release_notes: false
@@ -827,37 +817,33 @@ jobs:
     if: ${{ inputs.build_audioenc && !cancelled() && !failure() }}
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            build.env
+          sparse-checkout-cone-mode: false
 
       - name: Load version
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
-
           echo "VERSION=$ODR_AUDIOENC_VERSION" >> "$GITHUB_ENV"
 
-      - name: Download all artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          path: all_artifacts
-
-      - name: Organize AudioEnc artifacts
-        run: |
-          mkdir -p audioenc
-          mv all_artifacts/odr-audioenc-* audioenc/ || true
-          ls -l audioenc
+          path: artifacts
+          pattern: odr-audioenc-*
 
       - name: Create AudioEnc Release and Upload Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: softprops/action-gh-release@v2
         with:
-          files: audioenc/**
+          files: artifacts/**
           tag_name: odr-audioenc-${{ env.VERSION }}
           name: "ODR-AudioEnc ${{ env.VERSION }}"
           generate_release_notes: false
@@ -869,37 +855,33 @@ jobs:
     if: ${{ inputs.build_dabmux && !cancelled() && !failure() }}
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            build.env
+          sparse-checkout-cone-mode: false
 
       - name: Load version
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
-
           echo "VERSION=$ODR_DABMUX_VERSION" >> "$GITHUB_ENV"
 
-      - name: Download all artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          path: all_artifacts
-
-      - name: Organize DabMux artifacts
-        run: |
-          mkdir -p dabmux
-          mv all_artifacts/odr-dabmux-* dabmux/ || true
-          ls -l dabmux
+          path: artifacts
+          pattern: odr-dabmux-*
 
       - name: Create DabMux Release and Upload Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: softprops/action-gh-release@v2
         with:
-          files: dabmux/**
+          files: artifacts/**
           tag_name: odr-dabmux-${{ env.VERSION }}
           name: "ODR-DabMux ${{ env.VERSION }}"
           generate_release_notes: false
@@ -911,37 +893,33 @@ jobs:
     if: ${{ inputs.build_dablin && !cancelled() && !failure() }}
     permissions:
       contents: write
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            build.env
+          sparse-checkout-cone-mode: false
 
       - name: Load version
         run: |
-          # Source build.env file
           set -a
           . ./build.env
           set +a
-
           echo "VERSION=$DABLIN_VERSION" >> "$GITHUB_ENV"
 
-      - name: Download all artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v8
         with:
-          path: all_artifacts
-
-      - name: Organize DABlin artifacts
-        run: |
-          mkdir -p dablin
-          mv all_artifacts/dablin-* dablin/ || true
-          ls -l dablin
+          path: artifacts
+          pattern: dablin-*
 
       - name: Create DABlin Release and Upload Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: softprops/action-gh-release@v2
         with:
-          files: dablin/**
+          files: artifacts/**
           tag_name: dablin-${{ env.VERSION }}
           name: "DABlin ${{ env.VERSION }}"
           generate_release_notes: false

--- a/.github/workflows/odr-build.yml
+++ b/.github/workflows/odr-build.yml
@@ -800,6 +800,16 @@ jobs:
           path: artifacts
           pattern: odr-padenc-*
 
+      - name: Verify downloaded artifacts
+        run: |
+          artifact_count=$(find artifacts -type f | wc -l)
+          echo "Downloaded ${artifact_count} artifact files"
+          find artifacts -type f -print
+          if [ "$artifact_count" -eq 0 ]; then
+            echo "No ODR-PadEnc artifacts were downloaded" >&2
+            exit 1
+          fi
+
       - name: Create PadEnc Release and Upload Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -837,6 +847,16 @@ jobs:
         with:
           path: artifacts
           pattern: odr-audioenc-*
+
+      - name: Verify downloaded artifacts
+        run: |
+          artifact_count=$(find artifacts -type f | wc -l)
+          echo "Downloaded ${artifact_count} artifact files"
+          find artifacts -type f -print
+          if [ "$artifact_count" -eq 0 ]; then
+            echo "No ODR-AudioEnc artifacts were downloaded" >&2
+            exit 1
+          fi
 
       - name: Create AudioEnc Release and Upload Assets
         env:
@@ -876,6 +896,16 @@ jobs:
           path: artifacts
           pattern: odr-dabmux-*
 
+      - name: Verify downloaded artifacts
+        run: |
+          artifact_count=$(find artifacts -type f | wc -l)
+          echo "Downloaded ${artifact_count} artifact files"
+          find artifacts -type f -print
+          if [ "$artifact_count" -eq 0 ]; then
+            echo "No ODR-DabMux artifacts were downloaded" >&2
+            exit 1
+          fi
+
       - name: Create DabMux Release and Upload Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -913,6 +943,16 @@ jobs:
         with:
           path: artifacts
           pattern: dablin-*
+
+      - name: Verify downloaded artifacts
+        run: |
+          artifact_count=$(find artifacts -type f | wc -l)
+          echo "Downloaded ${artifact_count} artifact files"
+          find artifacts -type f -print
+          if [ "$artifact_count" -eq 0 ]; then
+            echo "No DABlin artifacts were downloaded" >&2
+            exit 1
+          fi
 
       - name: Create DABlin Release and Upload Assets
         env:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,14 +8,14 @@ ARG OS_VARIANT=debian13
 ARG TARGETARCH
 
 # Validate required args
-RUN test -n "$TOOL" || (echo "TOOL build arg is required" && exit 1)
-RUN test -n "$VERSION" || (echo "VERSION build arg is required" && exit 1)
+RUN test -n "$TOOL" || (echo "TOOL build arg is required" && exit 1) && \
+    test -n "$VERSION" || (echo "VERSION build arg is required" && exit 1)
 
 ENV REPO="oszuidwest/zwfm-odrbuilds"
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl file && \
+    ca-certificates curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /download
@@ -30,9 +30,6 @@ RUN if [ "$TOOL" = "odr-padenc" ] || [ "$TOOL" = "odr-dabmux" ]; then \
     DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TOOL}-${VERSION}/${BINARY_NAME}" && \
     echo "From: ${DOWNLOAD_URL}" && \
     curl -L --fail -o "${TOOL}" "${DOWNLOAD_URL}" && \
-    echo "Downloaded successfully, checking file..." && \
-    ls -la "${TOOL}" && \
-    file "${TOOL}" && \
     chmod +x "${TOOL}"
 
 # Runtime stage with conditional dependencies
@@ -41,22 +38,20 @@ FROM debian:trixie-slim AS runtime
 ARG TOOL
 ARG VARIANT=""
 
-# Install base dependencies that all tools need
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install tool-specific runtime dependencies
-RUN if [ "$TOOL" = "odr-padenc" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends libmagickwand-7.q16-10 locales && \
+# Install base + tool-specific runtime dependencies in a single layer
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    if [ "$TOOL" = "odr-padenc" ]; then \
+        apt-get install -y --no-install-recommends libmagickwand-7.q16-10 locales && \
         sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
         locale-gen; \
     elif [ "$TOOL" = "odr-dabmux" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends libzmq5 libboost-system1.83.0 libcurl4t64; \
+        apt-get install -y --no-install-recommends libzmq5 libboost-system1.83.0 libcurl4t64; \
     elif [ "$TOOL" = "odr-audioenc" ] && [ "$VARIANT" = "minimal" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends libzmq5 libcurl4t64 openssl; \
+        apt-get install -y --no-install-recommends libzmq5 libcurl4t64 openssl; \
     elif [ "$TOOL" = "odr-audioenc" ] && [ "$VARIANT" = "full" ]; then \
-        apt-get update && apt-get install -y --no-install-recommends \
-            libzmq5 libcurl4t64 libasound2t64 libjack0 libvlc5 vlc libvlc-dev \
+        apt-get install -y --no-install-recommends \
+            libzmq5 libcurl4t64 libasound2t64 libjack0 libvlc5 vlc \
             libgstreamer1.0-0 libgstreamer-plugins-base1.0-0 openssl; \
     fi && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,8 +8,8 @@ ARG OS_VARIANT=debian13
 ARG TARGETARCH
 
 # Validate required args
-RUN test -n "$TOOL" || (echo "TOOL build arg is required" && exit 1) && \
-    test -n "$VERSION" || (echo "VERSION build arg is required" && exit 1)
+RUN if [ -z "$TOOL" ]; then echo "TOOL build arg is required"; exit 1; fi; \
+    if [ -z "$VERSION" ]; then echo "VERSION build arg is required"; exit 1; fi
 
 ENV REPO="oszuidwest/zwfm-odrbuilds"
 
@@ -30,6 +30,7 @@ RUN if [ "$TOOL" = "odr-padenc" ] || [ "$TOOL" = "odr-dabmux" ]; then \
     DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TOOL}-${VERSION}/${BINARY_NAME}" && \
     echo "From: ${DOWNLOAD_URL}" && \
     curl -L --fail -o "${TOOL}" "${DOWNLOAD_URL}" && \
+    ls -la "${TOOL}" && \
     chmod +x "${TOOL}"
 
 # Runtime stage with conditional dependencies


### PR DESCRIPTION
## Summary
- Remove redundant comments, unused env vars, and unnecessary permissions across all workflows
- Optimize release jobs with sparse checkout and artifact download patterns (replacing manual organize steps)
- Fix AudioEnc dependency install to only pull full deps when the variant is actually `full` (minimal was unnecessarily installing ALSA, Jack, VLC, GStreamer)
- Merge Dockerfile layers and remove debug output and unused packages (`file`, `libvlc-dev`)

## Test plan
- [x] Trigger a full build via `odr-build.yml` and verify all artifacts are created correctly
- [x] Trigger `docker-build.yml` with `force_rebuild=true` and verify images work
- [x] Verify `docker-security.yml` still runs correctly on push